### PR TITLE
capture postgres config from env

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+use sqlx::postgres::PgConnectOptions;
+
+pub(super) fn match_postgres_env() -> Option<PgConnectOptions> {
+    let pg_password = env::var("POSTGRES_PASSWORD").ok();
+    let pg_user = env::var("POSTGRES_USER").ok();
+    let pg_db = env::var("POSTGRES_DB").ok();
+    let pg_host = env::var("POSTGRES_HOST").ok();
+    let pg_port = env::var("POSTGRES_PORT").ok()?.parse::<u16>().ok();
+
+    pg_password
+        .zip(pg_user)
+        .zip(pg_host)
+        .zip(pg_port)
+        .zip(pg_db)
+        .map(|x| {
+            PgConnectOptions::new()
+                .database(&x.1)
+                .port(x.0 .1)
+                .host(&x.0 .0 .1)
+                .username(&x.0 .0 .0 .1)
+                .password(&x.0 .0 .0 .0)
+        })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,11 @@ mod pricefeeds;
 
 mod oracle_scheduler;
 
-use crate::oracle::postgres::DBconnection;
+use crate::{env::match_postgres_env, oracle::postgres::DBconnection};
 
 mod api;
 mod cli;
+mod env;
 
 // const PAGE_SIZE: u32 = 100;
 
@@ -59,8 +60,12 @@ async fn main() -> anyhow::Result<()> {
         keypair.public_key().serialize().encode_hex::<String>()
     );
 
-    let (asset_pair_infos, oracle_scheduler_config, port, db_connect, max_connections_postgres) =
+    let (asset_pair_infos, oracle_scheduler_config, port, mut db_connect, max_connections_postgres) =
         args.match_args()?;
+
+    if let Some(env_postgres) = match_postgres_env() {
+        db_connect = env_postgres
+    }
 
     let db = DBconnection::new(db_connect, max_connections_postgres).await?;
 


### PR DESCRIPTION
If all the variables to build the postgres url are set in env, they are used to connect with postgres instead of command line arguments and default.