### PR TITLE
hotfix: ohlc[0] panic if ohlc is a vec of length 0

### DIFF
--- a/packages/pythia/src/pricefeeds/bitstamp.rs
+++ b/packages/pythia/src/pricefeeds/bitstamp.rs
@@ -66,6 +66,20 @@ impl PriceFeed for Bitstamp {
             )));
         }
 
-        Ok(res.data.unwrap().ohlc[0].open.parse().unwrap())
+        Ok(res
+            .data
+            .ok_or(PriceFeedError::Server(
+                "Failed to parse price from bitstamp: no data field".to_string(),
+            ))?
+            .ohlc
+            .first()
+            .ok_or(PriceFeedError::Server(
+                "Failed to parse price from bitstamp: no ohlc found".to_string(),
+            ))?
+            .open
+            .parse()
+            .map_err(|e| {
+                PriceFeedError::Server(format!("Failed to parse price from bitstamp: {e}"))
+            })?)
     }
 }


### PR DESCRIPTION
### Description

`test_all_pricefeeds` sometimes failed:

```bash 
thread 'pricefeeds::test::test_all_pricefeeds' panicked at packages/pythia/src/pricefeeds/bitstamp.rs:74:18:
index out of bounds: the len is 0 but the index is 0
```
Temporal fix: use first() method instead of indexing at postion 0