### PR TITLE
Follow up to PR #57: Add cargo-make for improved Rust workflow automation

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,33 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.default]
+dependencies = ["test"]
+
+[tasks.sqlx-prepare]
+description = "Prepare sqlx database for tests"
+command = "pnpm"
+args = ["sqlx-prepare"]
+
+[tasks.test]
+description = "Run all regular tests (excluding ignored benchmarks)"
+dependencies = ["sqlx-prepare"]
+command = "cargo"
+args = ["test"]
+
+[tasks.test-benchmark]
+description = "Run only benchmark tests (which are marked as ignored)"
+dependencies = ["sqlx-prepare"]
+command = "cargo"
+args = ["test", "--", "--ignored", "--nocapture"]
+
+[tasks.test-all]
+description = "Run all tests including benchmarks"
+dependencies = ["sqlx-prepare"]
+command = "cargo"
+args = ["test", "--", "--include-ignored"]
+
+[tasks.clean]
+description = "Remove artifacts in target directory"
+command = "cargo"
+args = ["clean"]

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Websocket answer:
 }
 ```
 
-## Run Pythia
+## Run Pythia (without Docker)
 
 To run pythia, first clone the repository:
 
@@ -357,6 +357,30 @@ docker compose up
 ```
 
 The API will run on port 8000.
+
+## Run tests using docker
+
+Pythia uses `cargo make` to make it easy to compile Pythia, set postgres in docker and its database and finally run the tests:
+
+```sh
+# Required if cargo make and sqlx are not yet installed:
+pnpm rust-prepare
+
+# Run test:
+cargo make test
+```
+
+One test is a small benchmark to choose the size of chunks to process the creation of the initial announcements at the first startup of Pythia (the chunks' size is currently set to 100 in normal run). It is ignored in previous command but you can run this test benchmark specifically using:
+
+```sh
+cargo make test-benchmark
+```
+
+And you can clean produced artifacts using:
+
+```sh
+cargo make clean
+```
 
 ### Scheduler configuration
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,8 +1,21 @@
 {
-  "dictionaries": ["bash", "docker", "node", "npm", "sql", "en-gb", "rust"],
+  "dictionaries": [
+    "bash",
+    "docker",
+    "node",
+    "npm",
+    "sql",
+    "en-gb",
+    "rust"
+  ],
   "language": "en",
-  "enableFiletypes": ["*"],
-  "ignorePaths": ["pnpm-lock.yaml", "Cargo.lock"],
+  "enableFiletypes": [
+    "*"
+  ],
+  "ignorePaths": [
+    "pnpm-lock.yaml",
+    "Cargo.lock"
+  ],
   "words": [
     "actix",
     "Afanassieff",
@@ -38,6 +51,7 @@
     "Michalakis",
     "nanos",
     "netcat",
+    "nocapture",
     "nsec",
     "oneshot",
     "Ohlc",

--- a/cspell.json
+++ b/cspell.json
@@ -1,21 +1,8 @@
 {
-  "dictionaries": [
-    "bash",
-    "docker",
-    "node",
-    "npm",
-    "sql",
-    "en-gb",
-    "rust"
-  ],
+  "dictionaries": ["bash", "docker", "node", "npm", "sql", "en-gb", "rust"],
   "language": "en",
-  "enableFiletypes": [
-    "*"
-  ],
-  "ignorePaths": [
-    "pnpm-lock.yaml",
-    "Cargo.lock"
-  ],
+  "enableFiletypes": ["*"],
+  "ignorePaths": ["pnpm-lock.yaml", "Cargo.lock"],
   "words": [
     "actix",
     "Afanassieff",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "release:version": "changeset version && pnpm install --lockfile-only && biome check . --write",
     "bake": "./scripts/bake.sh",
     "prepare": "./scripts/prepare.sh",
-    "sqlx-prepare": "./scripts/sqlx-prepare.sh"
+    "sqlx-prepare": "./scripts/sqlx-prepare.sh",
+    "rust-prepare": "./scripts/rust-prepare.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/scripts/rust-prepare.sh
+++ b/scripts/rust-prepare.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Installing Rust development tools..."
+
+# Check if cargo-make is installed
+if ! command -v cargo-make &> /dev/null; then
+    echo "Installing cargo-make..."
+    cargo install --force cargo-make
+else
+    echo "cargo-make is already installed"
+fi
+
+# Check if sqlx-cli is installed
+if ! command -v sqlx &> /dev/null; then
+    echo "Installing sqlx-cli..."
+    cargo install sqlx-cli --no-default-features --features native-tls,postgres
+else
+    echo "sqlx-cli is already installed"
+fi
+
+echo "Rust development tools installation complete!"


### PR DESCRIPTION
### Description
* On the JavaScript side, we use pnpm to execute commands and manage workflows. However, the Rust side lacks similar automation tooling to run groups of commands with a single instruction.
* This PR introduces `cargo-make`, which provides workflow automation for Rust projects, making it easier to run tests and other common development tasks through simple commands. As a cross-platform tool, cargo-make ensures consistent development experiences across Windows, macOS, and Linux environments.
* **Note**: This is a follow up PR. It should not be merged unless PR #57 is merged