### PR TITLE
Load variables defined current dir's .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 
 tsconfig.build.tsbuildinfo
 .vscode
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2212,7 @@ dependencies = [
  "displaydoc",
  "dlc",
  "dlc-messages",
+ "dotenv",
  "env_logger",
  "futures",
  "futures-buffered",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Pythia chooses `eventId` of announcements and attestation to be of the form `{as
 
 ## Configuration
 
-You can configure Pythia with the CLI arguments documented at `pythia --help` or environment variables.
+You can configure Pythia with the CLI arguments documented at `pythia --help`, environment variables, or a `.env` file. Pythia automatically loads environment variables from a `.env` file in the current working directory.
+Configuration precedence (highest to lowest): CLI arguments > environment variables > `.env` file.
 
 Pythia will run an http server on port `8000` by default but you can change it with the `--port` argument or the `PORT` environment variable.
 

--- a/packages/pythia/Cargo.toml
+++ b/packages/pythia/Cargo.toml
@@ -20,6 +20,7 @@ dlc = { git = "https://github.com/p2pderivatives/rust-dlc.git", branch = "master
     "serde",
 ] }
 env_logger = "0.10.2"
+dotenv = "0.15"
 hex = "0.4"
 humantime = "2.1.0"
 lightning = "0.0.125"

--- a/packages/pythia/src/api/http.rs
+++ b/packages/pythia/src/api/http.rs
@@ -185,7 +185,7 @@ pub(super) async fn oracle_batch_announcements_service<Context: OracleContext>(
         .0
         .maturities
         .iter()
-        .map(|ts| (oracle.asset_pair_info.asset_pair.to_string() + &ts.timestamp().to_string()))
+        .map(|ts| oracle.asset_pair_info.asset_pair.to_string() + &ts.timestamp().to_string())
         .collect::<Vec<_>>();
 
     (!oracle

--- a/packages/pythia/src/main.rs
+++ b/packages/pythia/src/main.rs
@@ -24,6 +24,9 @@ static SECP: LazyLock<Secp256k1<All>> = const { LazyLock::new(Secp256k1::new) };
 
 #[actix_web::main]
 async fn main() -> Result<(), PythiaError> {
+    // Load environment variables from .env file if it exists
+    dotenv::dotenv().ok();
+
     env_logger::init();
 
     // Parse command line arguments and environnement variables to create CONFIG

--- a/packages/pythia/src/oracle/postgres/mod.rs
+++ b/packages/pythia/src/oracle/postgres/mod.rs
@@ -66,6 +66,13 @@ pub(crate) struct DBconnection(pub PgPool);
 impl DBconnection {
     /// Create a new Db connection with postgres
     pub(crate) async fn new(db_connect: PgConnectOptions, max_connection: u32) -> Result<Self> {
+        info!(
+            "Connecting to PostgreSQL database {} at {}:{}",
+            db_connect.get_database().unwrap_or("<unset>"),
+            db_connect.get_host(),
+            db_connect.get_port()
+        );
+
         Ok(DBconnection(
             PgPoolOptions::new()
                 .max_connections(max_connection)


### PR DESCRIPTION
I was trying out pythia and I thought it'd be interesting to use dotenv instead of chaining commadn args/env variables